### PR TITLE
Initialize Order's OrderItems so join scenarios can be tested

### DIFF
--- a/WebApp/SampleOdataService/DataSource/OrderDataSource.cs
+++ b/WebApp/SampleOdataService/DataSource/OrderDataSource.cs
@@ -28,13 +28,12 @@ namespace TicketDataService.DataSource
 		{
 			get
 			{
-				//var exeFile = Assembly.GetExecutingAssembly().Location;
-				//var dir = Path.GetDirectoryName(exeFile);
-
 				var json = File.ReadAllText(System.Web.Hosting.HostingEnvironment.MapPath(HttpContext.Current.Request.ApplicationPath) + "\\orders.txt");
 
-				return JsonConvert.DeserializeObject<Order[]>(json).AsQueryable();
-
+				var orders = JsonConvert.DeserializeObject<Order[]>(json).AsQueryable();
+				orders.First().OrderItems = OrderItemDataSource.Instance.OrderItems.ToArray();
+				orders.Last().OrderItems = OrderItemDataSource.Instance.OrderItems.ToArray();
+				return orders;
 			}
 		}
 	}


### PR DESCRIPTION
If you join Orders on OrderItems right now you'll get 0 results since we only return Orders with > 0 OrderItems in the OData plugin. This should solve that although I'm not sure how to deploy/test a new version of the service to test that is true.